### PR TITLE
assign revision name to existing revision

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -38,12 +38,14 @@ async function main() {
       return;
     }
 
-    let traffics = [];
-    currentAppProperty.configuration!.ingress!.traffic!.forEach((traffic: TrafficWeight) => {
-      if (traffic.weight && traffic.weight > 0) {
-        traffics.push(traffic);
+    const traffics = currentAppProperty.configuration!.ingress!.traffic!.filter((traffic: TrafficWeight) => {
+      if (!traffic.weight || traffic.weight === 0) return false
+      if (traffic.latestRevision) {
+        traffic.latestRevision = false;
+        traffic.revisionName = currentAppProperty.latestRevisionName;
       }
-    });
+      return true;
+    }) || [];
     traffics.push({
       revisionName: `${taskParams.containerAppName}--${taskParams.revisionNameSuffix}`,
       weight: 0,


### PR DESCRIPTION
To resolve #41 ,
- set `latestRevisionName` as revision name to an existing revision that doesn't have the name.